### PR TITLE
remove duplicate content-type "application/json"

### DIFF
--- a/src/events/DefaultEventSender.ts
+++ b/src/events/DefaultEventSender.ts
@@ -32,7 +32,6 @@ export class DefaultEventSender implements IEventSender {
 
     const headers: Record<string, string> = {
       ...this.defaultHeaders,
-      'content-type': 'application/json',
     }
 
     let error;


### PR DESCRIPTION
Requests such as `/api/public/insight/track` ends up with a duplicate content-type which is flagged by some WAF (such as ModSecurity) 

before this change:
`content-type: application/json, application/json`

after this change:
`content-type: application/json`