### PR TITLE
fix: include user-agent headers in http requests

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -2,6 +2,7 @@ import { IInfo } from "../platform/IInfo";
 
 export type Headers = {
   Authorization: string;
+  'User-Agent': string;
   'X-User-Agent': string;
   'Content-Type': string;
 };
@@ -15,6 +16,7 @@ export function defaultHeaders(
   const headers: Headers = {
     'Content-Type': 'application/json',
     'X-User-Agent': userAgent ?? `${info.appType}/${version}`,
+    'User-Agent': userAgent ?? `${info.appType}/${version}`,
     'Authorization': sdkKey
   };
 


### PR DESCRIPTION
- Adds a standard User-Agent header to all outgoing HTTP requests, using the same value already set on X-User-Agent. Some server-side gateways and proxies rely on the standard User-Agent header for request identification, while the non-standard X-User-Agent alone may be stripped or ignored.

  Changes:
  - Added User-Agent to the Headers type
  - Set User-Agent in defaultHeaders() alongside the existing X-User-Agent

Closes: #18 
